### PR TITLE
Fix address typings for scheduler transactions

### DIFF
--- a/src/components/recurring-scheduler.tsx
+++ b/src/components/recurring-scheduler.tsx
@@ -6,7 +6,7 @@ import {
   useReadContract,
   useWriteContract,
 } from "wagmi";
-import { erc20Abi, formatUnits, parseUnits } from "viem";
+import { Address, erc20Abi, formatUnits, parseUnits } from "viem";
 import { waitForTransactionReceipt } from "wagmi/actions";
 
 import { config } from "@/lib/wagmi";
@@ -21,8 +21,8 @@ type Recurrence = "daily" | "weekly" | "monthly" | "custom";
 
 interface Schedule {
   id: string;
-  owner: string;
-  recipient: string;
+  owner: Address;
+  recipient: Address;
   amount: string;
   recurrence: Recurrence;
   everyDays?: number;
@@ -84,8 +84,8 @@ function persistSchedules(all: Schedule[]) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
 }
 
-function sanitizedAddress(value: string) {
-  return value.trim().toLowerCase();
+function sanitizedAddress(value: string): Address {
+  return value.trim().toLowerCase() as Address;
 }
 
 function isValidAddress(value: string) {
@@ -170,7 +170,7 @@ function formatRelativeTime(targetIso: string, now: Date) {
   return formatter.format(diffYears, "year");
 }
 
-function makeSchedule(form: FormState, owner: string): Schedule {
+function makeSchedule(form: FormState, owner: Address): Schedule {
   const base = new Date(form.startAt ? form.startAt : new Date().toISOString());
   const sanitizedOwner = sanitizedAddress(owner);
   const record: Schedule = {
@@ -189,7 +189,7 @@ function makeSchedule(form: FormState, owner: string): Schedule {
   return record;
 }
 
-function filterByOwner(all: Schedule[], owner?: string | null) {
+function filterByOwner(all: Schedule[], owner?: Address | null) {
   if (!owner) {
     return createEmptySchedules();
   }

--- a/src/lib/pyusd.ts
+++ b/src/lib/pyusd.ts
@@ -1,4 +1,7 @@
-export const PYUSD_ADDRESS = "0xCaC524BcA292aaade2DF8A05cC58F0a65B1B3bB9" as const;
+import { Address } from "viem";
+
+export const PYUSD_ADDRESS: Address =
+  "0xCaC524BcA292aaade2DF8A05cC58F0a65B1B3bB9";
 export const PYUSD_DECIMALS = 6;
 export const PYUSD_SYMBOL = "PYUSD";
 export const PYUSD_NAME = "PayPal USD";


### PR DESCRIPTION
## Summary
- type recurring schedule owner and recipient fields as viem `Address`
- sanitize stored addresses with the typed helper and update usage
- export the PYUSD token address with the correct viem `Address` type

## Testing
- `npm run build` *(fails: next/font could not fetch Geist fonts in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8cc144e38832882e45b2936cc0361