### PR TITLE
Fix wallet connection status reference in scheduler

### DIFF
--- a/src/components/recurring-scheduler.tsx
+++ b/src/components/recurring-scheduler.tsx
@@ -6,7 +6,7 @@ import {
   useReadContract,
   useWriteContract,
 } from "wagmi";
-import { erc20Abi, formatUnits, parseUnits } from "viem";
+import { Address, erc20Abi, formatUnits, parseUnits } from "viem";
 import { waitForTransactionReceipt } from "wagmi/actions";
 
 import { config } from "@/lib/wagmi";
@@ -21,8 +21,8 @@ type Recurrence = "daily" | "weekly" | "monthly" | "custom";
 
 interface Schedule {
   id: string;
-  owner: string;
-  recipient: string;
+  owner: Address;
+  recipient: Address;
   amount: string;
   recurrence: Recurrence;
   everyDays?: number;
@@ -84,8 +84,8 @@ function persistSchedules(all: Schedule[]) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
 }
 
-function sanitizedAddress(value: string) {
-  return value.trim().toLowerCase();
+function sanitizedAddress(value: string): Address {
+  return value.trim().toLowerCase() as Address;
 }
 
 function isValidAddress(value: string) {
@@ -170,7 +170,7 @@ function formatRelativeTime(targetIso: string, now: Date) {
   return formatter.format(diffYears, "year");
 }
 
-function makeSchedule(form: FormState, owner: string): Schedule {
+function makeSchedule(form: FormState, owner: Address): Schedule {
   const base = new Date(form.startAt ? form.startAt : new Date().toISOString());
   const sanitizedOwner = sanitizedAddress(owner);
   const record: Schedule = {
@@ -189,7 +189,7 @@ function makeSchedule(form: FormState, owner: string): Schedule {
   return record;
 }
 
-function filterByOwner(all: Schedule[], owner?: string | null) {
+function filterByOwner(all: Schedule[], owner?: Address | null) {
   if (!owner) {
     return createEmptySchedules();
   }
@@ -198,7 +198,7 @@ function filterByOwner(all: Schedule[], owner?: string | null) {
 }
 
 export function RecurringScheduler() {
-  const { address, isConnected } = useAccount();
+  const { address, isConnected, status: connectionStatus } = useAccount();
   const [form, setForm] = useState<FormState>(initialFormState);
   const [schedules, setSchedules] = useState<Schedule[]>(createEmptySchedules());
   const [now, setNow] = useState(new Date());
@@ -509,7 +509,7 @@ export function RecurringScheduler() {
             <button
               className="w-full rounded-xl bg-emerald-500 px-4 py-3 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-emerald-500/50"
               type="submit"
-              disabled={!isConnected || connectStatus === "connecting"}
+              disabled={!isConnected || connectionStatus === "connecting"}
             >
               {isConnected ? "Add schedule" : "Connect wallet to create"}
             </button>

--- a/src/lib/pyusd.ts
+++ b/src/lib/pyusd.ts
@@ -1,4 +1,7 @@
-export const PYUSD_ADDRESS = "0xCaC524BcA292aaade2DF8A05cC58F0a65B1B3bB9" as const;
+import { Address } from "viem";
+
+export const PYUSD_ADDRESS: Address =
+  "0xCaC524BcA292aaade2DF8A05cC58F0a65B1B3bB9";
 export const PYUSD_DECIMALS = 6;
 export const PYUSD_SYMBOL = "PYUSD";
 export const PYUSD_NAME = "PayPal USD";


### PR DESCRIPTION
## Summary
- rename the `useAccount` status destructuring to `connectionStatus`
- use the renamed connection status flag to keep schedule creation disabled while the wallet connects

## Testing
- `npm run build` *(fails: next/font cannot download Geist fonts in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8cc144e38832882e45b2936cc0361